### PR TITLE
Fix UnicodeDecodeError when reading files in 'utf-8'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ ass2srt is a Python script that allows you to convert `.ass` subtitle files to `
 ## Requirements
 
 - Python 3.x
-- `pysubs2` library
+- `pysubs2` `chardet` library
 
 ## Usage
 
 1. Clone this repository or download the `convert_ass_to_srt.py` script.
 2. Ensure that you have Python installed on your system.
-3. Install the required `pysubs2` library by running the following command: ``pip install pysubs2``
+3. Install the required `pysubs2` and `chardet` library by running the following command: ``pip install pysubs2 chardet``

--- a/ass2srt.py
+++ b/ass2srt.py
@@ -1,5 +1,6 @@
 import os
 import pysubs2
+import chardet
 
 # Prompt the user to enter the directory path
 directory = input("Enter the directory path where the .ass files are located: ")
@@ -17,8 +18,12 @@ for ass_file in ass_files:
     # Generate the corresponding .srt filename
     srt_file = os.path.splitext(ass_file)[0] + '.srt'
 
+    # Detect the file encoding
+    raw_data = open(os.path.join(directory, ass_file), 'rb').read()
+    file_enc = chardet.detect(raw_data)['encoding']
+
     # Open the .ass file using pysubs2
-    subs = pysubs2.load(os.path.join(directory, ass_file), encoding='utf-8')
+    subs = pysubs2.load(os.path.join(directory, ass_file), encoding=file_enc)
 
     # Save the subtitles as .srt
     subs.save(os.path.join(directory, srt_file), encoding='utf-8')


### PR DESCRIPTION
### Problem
When trying to load subtitle files using the `pysubs2` library, the program crashes if the file encoding is not compatible with UTF-8. The following error occurs:
```
Traceback (most recent call last):
File "/home/lyferlu/Program/test/ass2srt/ass2srt.py", line 21, in <module>
subs = pysubs2.load(os.path.join(directory, ass_file), encoding='utf-8')
File "/home/lyferlu/Program/test/ass2srt/.venv/lib/python3.12/site-packages/pysubs2/ssafile.py", line 104, in load
return cls.from_file(fp, format_, fps=fps, **kwargs)
File "/home/lyferlu/Program/test/ass2srt/.venv/lib/python3.12/site-packages/pysubs2/ssafile.py", line 155, in from_file
text = fp.read()
File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```
I have tested this fix with various encoded subtitle files, and it now handles files with UTF-8 and other encodings without crashing.

Please review and let me know if further changes are required.